### PR TITLE
Add steps for generating new master certificates

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -58,7 +58,7 @@ ifdef::openshift-origin[]
 If your OpenShift installation was originally performed on a version previous to
 v1.0.8, even if it has since been updated to a newer version, you will need to 
 follow these steps outlined in the
-link:upgrades.html#openshift-origin-pre-1-0-8-certificate-update[update]
+link:upgrades.html#updating-node-certificates[update]
 document. If the node certificate does not contain the IP address of the node, then Heapster
 will fail to retrieve any metrics.
 ====

--- a/install_config/upgrades.adoc
+++ b/install_config/upgrades.adoc
@@ -832,6 +832,286 @@ build of those applications after importing the new images using `oc start-build
 <app-name>`.
 ====
 
+[[updating-master-and-node-certificates]]
+=== Updating Master and Node Certificates
+
+ifdef::openshift-enterprise[]
+The following steps may be required for any OpenShift instance which
+was originally installed prior to the
+link:../release_notes/ose_3_1_release_notes.adoc[OpenShift Enterprise
+3.1 release].  This may include any and all updates from that version.
+endif::[]
+ifdef::openshift-origin[]
+The following steps may be required for any OpenShift instance which
+was originally installed prior to the
+link:https://github.com/openshift/origin/releases[OpenShift Origin
+1.0.8 release].  This may include any and all updates from that
+version.
+endif::[]
+
+[[updating-node-certificates]]
+==== Node Certificates
+
+ifdef::openshift-enterprise[]
+With the 3.1 release, certificates for each of the kubelet nodes
+were updated to include the IP address of the node. Any node
+certificates generated before the 3.1 release may not contain the IP
+address of the node.
+endif::[]
+ifdef::openshift-origin[]
+With the 1.0.8 release, certificates for each of the kubelet nodes
+were updated to include the IP address of the node. Any node
+certificates generated before the 1.0.8 release may not contain the IP
+address of the node.
+endif::[]
+
+If a node is missing the IP address as part of its certificate,
+clients may refuse to connect to the kubelet endpoint. Usually this
+will result in errors regarding the certificate not containing an `IP
+SAN`
+
+In order to remedy this situation, you may need to manually update the
+certificates for your node.
+
+===== Checking the Node's Certificate
+
+The following command can be used to determine which `Subject
+Alternative Names` are present in the node's serving certificate. In
+this example, the `Subject Alternative Names` are: mynode,
+mynode.mydomain.com, 1.2.3.4.
+
+----
+# openssl x509 -in /etc/origin/node/server.crt -text -noout | grep -A 1 "Subject Alternative Name"
+X509v3 Subject Alternative Name:
+DNS:mynode, DNS:mynode.mydomain.com, IP: 1.2.3.4
+----
+
+Ensure that the `nodeIP` value set in
+*_/etc/origin/node/node-config.yaml_* is present in the IP values from
+the `Subject Alternative Names` listed in the node's serving
+certificate. If the `nodeIP` is not present then it will need to be
+added to the node's certificate.
+
+If the `nodeIP` value is already contained within the `Subject
+Alternative Names`, then no further steps are required.
+
+You will need to know the `Subject Alternative Names` and `nodeIP`
+value for the following steps.
+
+===== Generating a New Node Certificate
+
+If your current node certificate does not contain the proper IP
+address, then you will need to regenerate a new certificate for your
+node.
+
+[IMPORTANT]
+Node certificates will be regenerated on the master (or first master)
+and are then copied into place on node systems.
+
+. Create a temporary directory in which to perform the following steps
++
+----
+# mkdir /tmp/node_certificate_update
+# cd /tmp/node_certificate_update
+----
+
+. Export signing options:
++
+----
+# export signing_opts="--signer-cert=/etc/origin/master/ca.crt --signer-key=/etc/origin/master/ca.key --signer-serial=/etc/origin/master/ca.serial.txt"
+----
+
+. Generate the new certificate
++
+
+----
+# oadm ca create-server-cert --cert=server.crt \
+  --key=server.key $signing_opts \
+  --hostnames=<existing subject alt names>,<nodeIP>
+----
++
+For example, if the `Subject Alternative Names` from before were
+_mynode,mynode.mydomain.com,1.2.3.4_ and the `nodeIP` was 10.10.10.1,
+then you will need to run the following command:
++
+----
+# oadm ca create-server-cert --cert=server.crt \
+  --key=server.key $signing_opts \
+  --hostnames=mynode,mynode.mydomain.com,1.2.3.4,10.10.10.1
+----
+
+
+===== Replace Node Serving Certificates
+
+Back up the existing *_/etc/origin/node/server.crt_* and
+*_/etc/origin/node/server.key_* file for your node:
+
+----
+# mv /etc/origin/node/server.crt /etc/origin/node/server.crt.bak
+# mv /etc/origin/node/server.key /etc/origin/node/server.key.bak
+----
+
+You will now need to copy the new *_server.crt_* and *_server.key_*
+created in the temporary directory during the previous step.
+
+====
+----
+# mv /tmp/node_certificate_update/server.crt /etc/origin/node/server.crt
+# mv /tmp/node_certificate_update/server.key /etc/origin/node/server.key
+----
+====
+
+After you have replaced the node's certificate, you will now need to
+restart the node service.
+
+ifdef::openshift-enterprise[]
+----
+# systemctl restart atomic-openshift-node
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+# systemctl restart origin-node
+----
+endif::[]
+
+[[updating-master-certificates]]
+==== Master Certificates
+
+ifdef::openshift-enterprise[]
+With the 3.1 release, certificates for each of the masters were
+updated to include all names that pods may use to communicate with
+masters. Any master certificates generated before the 3.1 release may
+not contain these additional service names.
+endif::[]
+ifdef::openshift-origin[]
+With the 1.0.8 release, certificates for each of the masters were
+updated to include all names that pods may use to communicate with
+masters. Any master certificates generated before the 1.0.8 release
+may not contain these additional service names.
+endif::[]
+
+==== Checking the Master's Certificate
+
+The following command can be used to determine which `Subject
+Alternative Names` are present in the master's serving certificate. In
+this example, the `Subject Alternative Names` are: mymaster,
+mymaster.mydomain.com, 1.2.3.4.
+
+----
+# openssl x509 -in /etc/origin/master/master.server.crt -text -noout | grep -A 1 "Subject Alternative Name"
+X509v3 Subject Alternative Name:
+DNS:mymaster, DNS:mymaster.mydomain.com, IP: 1.2.3.4
+----
+
+Ensure that the following entries are present in the `Subject
+Alternative Names` for the master's serving certificate:
+
+* Kubernetes service IP address ex: 172.30.0.1
+* All master hostnames ex: master1.example.com
+* All master IP addresses ex: 192.168.122.1
+* Public master hostname in clustered environments ex: public-master.example.com
+* kubernetes
+* kubernetes.default
+* kubernetes.default.svc
+* kubernetes.default.svc.cluster.local
+* openshift
+* openshift.default
+* openshift.default.svc
+* openshift.default.svc.cluster.local
+
+If these names are already contained within the `Subject Alternative
+Names`, then no further steps are required.
+
+===== Generating a New Master Certificate
+
+If your current master certificate does not contain all names from the
+list above, then you will need to generate a new certificate for your
+master.
+
+. Back up the existing *_/etc/origin/master/master.server.crt_* and
+*_/etc/origin/master/master.server.key_* file for your master:
++
+----
+# mv /etc/origin/master/master.server.crt /etc/origin/master/master.server.crt.bak
+# mv /etc/origin/master/master.server.key /etc/origin/master/master.server.key.bak
+----
+
+. Export service names
++
+These names will be used when generating the new certificate.
++
+----
+# export service_names="kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local,openshift,openshift.default,openshift.default.svc,openshift.default.svc.cluster.local"
+----
+
+. Generate the new certificate
++
+You will need the first IP in the services subnet (kubernetes service
+IP) as well as the values of `masterIP`, `masterURL` and
+`publicMasterURL` contained in
+*_/etc/origin/master/master-config.yaml_* for the following steps.
++
+The kubernetes service IP can be obtained with:
++
+----
+# oc get svc/kubernetes --template='{{.spec.clusterIP}}'
+----
++
+====
+----
+# oadm ca create-master-certs \
+  --hostnames=<master hostnames>,<master IP addresses>,<kubernetes service IP>,$service_names \ <1> <2> <3>
+  --master=<internal master address> \ <4>
+  --public-master=<public master address> \ <5>
+  --cert-dir=/etc/origin/master/ \
+  --overwrite=false
+----
+<1> Adjust master hostname to match your master hostname. In a clustered environment, add all master hostnames.
+<2> Adjust master IP address to match the value of `masterIP`. In a clustered environment, add all master IP addresses.
+<3> The first IP in the services subnet (Kubernetes service IP).
+<4> Adjust internal master address to match the value of `masterURL`.
+<5> Adjust public master address to match the value of `masterPublicURL`.
+====
+
++
+. Restart master services
++
+
+Single master deployments:
++
+ifdef::openshift-enterprise[]
+----
+# systemctl restart atomic-openshift-master
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+# systemctl restart origin-master
+----
+endif::[]
++
+`native` multi-master deployments:
++
+ifdef::openshift-enterprise[]
+----
+# systemctl restart atomic-openshift-master-api
+# systemctl restart atomic-openshift-master-controllers
+----
+endif::[]
+ifdef::openshift-origin[]
+----
+# systemctl restart origin-master-api
+# systemctl restart origin-master-controllers
+----
+endif::[]
++
+`pacemaker` multi-master deployments:
++
+----
+# pcs resource restart master
+----
+
 [[additional-instructions-per-release]]
 === Additional Manual Steps Per Release
 
@@ -1091,116 +1371,5 @@ Modify the *_/etc/origin/master/scheduler.json_* file to add the `*kind*` and
 ====
 <1> Add `*"kind": "Policy",*`
 <2> Add `*"apiVersion": "v1",*`
-
-[[openshift-origin-pre-1-0-8-certificate-update]]
-==== OpenShift Origin Pre 1.0.8 Installation and Kubelet Certificates
-
-The following steps may be required for any OpenShift instance which was originally installed 
-previous to the https://github.com/openshift/origin/releases[OpenShift Origin 1.0.8 release].
-This may include any and all updates from that version.
-
-With the 1.0.8 release, the certificates for each of the kubelet nodes were updated to include
-the IP address of the node. Any node certificates generated before the 1.0.8 release may not 
-contain the IP address of the node.
-
-If a node is missing the IP address as part of its certificate, clients may refuse to connect
-to the kubelet endpoint. Usually this will result in errors about the certificate not containing
-an `IP SAN`
-
-In order to remedy this situation, you may need to manually update the certificates for your node.
-
-*Checking the Node's Certificate*
-
-The follow command can be used to determine what subject alt names are already in place for the 
-node's serving certificate:
-
-====
-----
-# openssl x509 -in /etc/origin/node/server.crt -text -noout | grep -A 1 "Subject Alternative Name"
-----
-====
- 
-If the output shows:
-====
-----
-X509v3 Subject Alternative Name:
-DNS:mynode, DNS:mynode.mydomain.com, IP: 1.2.3.4
-----
-====
-
-then your subject alt names are:
-====
-----
-mynode
-mynode.mydomain.com
-1.2.3.4
-----
-====
-
-You will now need to check that the `nodeIP` value in the  *_/etc/origin/node/node-config.yaml_* configuration file. If this value
-does not match one of the IP values from the subject alternative names determined in the previous step then it will need to be added to the node's certificate.
-
-If the `nodeIP` value is already contained within the subject alternative names, then no further steps are required.
-
-You will need to know the `Subject Alternative Names` and `nodeIP` value for the following steps.
- 
-
-*Generating a New Node Certificate*
-
-If your current node certificate do not contain the proper IP address, then you will need to regenerate a new certificate for your node.
-
-We will perform the following commands from a temporary directory:
-
-====
-----
-# mkdir /tmp/node_certificate_update
-# cd /tmp/node_certificate_update
-----
-====
-
-First we will export a variable to contain all our signing options:
-====
-----
-# export signing_opts="--signer-cert=/etc/origin/master/ca.crt --signer-key=/etc/origin/master/ca.key --signer-serial=/etc/origin/master/ca.serial.txt"
-----
-====
-
-Then we need to generate the new certificate
-
-====
-----
-# oadm ca create-server-cert --cert=server.crt --key=server.key $signing_opts --hostnames=<existing subject alt names>,<nodeIP>
-----
-==== 
-
-For example, if the `Subject Alternative Name` from before was _mynode,mynode.mydomain.com,1.2.3.4_ and the `nodeIP` was 10.10.10.1, then 
-you will need to run the following command:
-====
-----
-# oadm ca create-server-cert --cert=server.crt --key=server.key $signing_opts --hostnames=mynode,mynode.mydomain.com,1.2.3.4,10.10.10.1
-----
-====
-
-*Replace Node Serving Certificates*
-
-Back up the existing *_/etc/origin/node/server.crt_* and *_/etc/origin/node/server.key_* file for your node:
-
-====
-----
-# mv /etc/origin/node/server.crt /etc/origin/node/server.crt.bak
-# mv /etc/origin/node/server.key /etc/origin/node/server.key.bak
-----
-====
-
-You will now need to copy the new *_server.crt_* and *_server.key_* created in the temporary directory during the previous step 
-
-====
-----
-# mv /tmp/node_certificate_update/server.crt /etc/origin/node/server.crt
-# mv /tmp/node_certificate_update/server.key /etc/origin/node/server.key
-----
-====
-
-After you have replaced the node's certificate, you will now need to restart the node service.
 endif::[]
 


### PR DESCRIPTION
I've been working on master certificate steps and since they fit into the same area I've built them on top of your node certificate PR.
- Moved section above additional manual steps.
- Made some minor changes to flow.
- Added steps for generating new master certificates which have been updated to contain all possible service names as well as the first IP in the services subnet (kubernetes service ip address).

Question about the node certificates: should the warning in cluster metrics also be presented for enterprise installations?

Let me know if you have any questions - feel free to merge and chop this up some more.

[origin pretty build](http://file.rdu.redhat.com/abutcher/openshift-docs/openshift-origin/master-certificates/install_config/upgrades.html#updating-master-and-node-certificates)

[enterprise pretty build](http://file.rdu.redhat.com/abutcher/openshift-docs/openshift-enterprise/master-certificates/install_config/upgrades.html#updating-master-and-node-certificates)
